### PR TITLE
Add links for notebooks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@ As part of the DSCI 525 project we will be building and deploying ensemble Machi
 
 ## Milestone 1 Notebook
 
-A Jupyter notebook exploring loading and storing a large dataset in memory directly can be found [here](https://github.com/UBC-MDS/525_group16/blob/main/notebooks/Milestone1.ipynb)
-
+- A Jupyter notebook exploring loading and storing a large dataset in memory directly can be found [here](https://github.com/UBC-MDS/525_group16/blob/main/notebooks/Milestone1.ipynb)
+- A Jupyter notebook getting data from S3 instance and making data ready for machine learning can be found [here](https://github.com/UBC-MDS/525_group16/blob/main/notebooks/Milestone2.ipynb)
+- A folder contains a Python 3 notebook with the code for ML model in scikit-learn, a PySpark notebook with the code for obtaining best hyperparameter settings, and some screenshots can be found [here](https://github.com/UBC-MDS/525_group16/tree/main/notebooks/milestone3)
+- A folder contains a notebook with the solution for developing and deploying API, and some screenshots can be found [here](https://github.com/UBC-MDS/525_group16/tree/main/notebooks/milestone4)


### PR DESCRIPTION
This pr adds all the links to notebooks for each milestone in `README.md` file.